### PR TITLE
Read all the scales!

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,33 @@ Node application that reads a file stream, parses its input as a weight measurem
 - https://github.com/Springworks/usbscale
 - https://github.com/Springworks/usbscale-runner
 
+## Usage
+
+Install NPM module:
+```
+npm install -g scale-reader
+```
+
+Read data from a file and transmit stable values to a server endpoint:
+```
+scale-reader --help
+
+  Usage: scale-reader [options]
+
+  Options:
+
+    -h, --help                                output usage information
+    -F, --filename <path to file>             Path to file to read weight from
+    -T, --target-url <url to PATCH endpoint>  Target URL
+```
+
+Data transmission is a `PATCH` to `--target-url` with body:
+```json
+{
+  "grams": 1025,
+  "timestamp": 2015-12-08T12:35:43.771Z"
+}
+```
+
 ## License
 MIT

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+require('babel/polyfill');
+
+var cli = require('../lib/cli');
+cli.run(process);

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.1",
   "description": "Application that reads value off a scale from a local file stream",
   "main": "./lib/index.js",
+  "bin": {
+    "scale-reader": "./bin/cli.js"
+  },
   "scripts": {
     "prepublish": "npm run build",
     "build": "rm -rf lib && babel src --out-dir lib",
@@ -31,6 +34,14 @@
     "babel-eslint": "^4.1.3",
     "eslint": "1.7.3",
     "eslint-config-springworks": "3.2.0",
-    "eslint-plugin-mocha": "1.0.0"
+    "eslint-plugin-mocha": "1.0.0",
+    "mocha": "2.3.4",
+    "istanbul": "0.4.1"
+  },
+  "dependencies": {
+    "request": "^2.65.0",
+    "always-tail": "0.2.0",
+    "commander": "2.9.0",
+    "lodash.takeright": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,19 +29,20 @@
   },
   "homepage": "https://github.com/Springworks/node-scale-reader",
   "devDependencies": {
-    "@springworks/test-harness": "^1.2.2",
-    "babel": "^5.8.29",
-    "babel-eslint": "^4.1.3",
+    "@springworks/test-harness": "1.2.2",
+    "babel": "5.8.29",
+    "babel-eslint": "4.1.3",
     "eslint": "1.7.3",
     "eslint-config-springworks": "3.2.0",
     "eslint-plugin-mocha": "1.0.0",
-    "mocha": "2.3.4",
-    "istanbul": "0.4.1"
+    "eslint-plugin-should-promised": "1.0.5",
+    "istanbul": "0.4.1",
+    "mocha": "2.3.4"
   },
   "dependencies": {
-    "request": "^2.65.0",
+    "request": "2.65.0",
     "always-tail": "0.2.0",
     "commander": "2.9.0",
-    "lodash.takeright": "^3.0.0"
+    "lodash.takeright": "3.0.0"
   }
 }

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1,0 +1,17 @@
+const program = require('commander');
+const main = require('../index');
+
+exports.run = function(process) {
+  program
+      .option('-F, --filename <path to file>', 'Path to file to read weight from')
+      .option('-T, --target-url <url to PATCH endpoint>', 'Target URL')
+      .parse(process.argv);
+
+  console.log('');
+  console.log('Reading weight from %s, sending changes to %s', program.filename, program.targetUrl);
+  console.log('');
+
+  main.run(program.filename, program.targetUrl);
+
+  console.log('Waiting...');
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,22 @@
+import weight_responder from './weight-responder';
+import measurement_analyzer from './measurement-analyzer';
+import http_transmitter from './transmission/http-transmitter';
+import weight_transmitter from './transmission/weight-transmitter';
+import weight_reader from './weight-reader';
+
+const api = {
+  run(filename, target_url) {
+    const http_config = {
+      target_url: target_url,
+      method: 'patch',
+    };
+
+    const transmitter = weight_transmitter.create(http_transmitter.create(http_config));
+    const analyzer = measurement_analyzer.create();
+    const responder = weight_responder.create(transmitter, analyzer);
+    const reader = weight_reader.create(filename, responder);
+    reader.read();
+  },
+};
+
+export default api;

--- a/src/measurement-analyzer.js
+++ b/src/measurement-analyzer.js
@@ -1,0 +1,34 @@
+import takeRight from 'lodash.takeright';
+
+const api = {
+  create() {
+    const recent_measurements = [];
+    return {
+      isStabilized() {
+        const MINIMUM_EQUAL_VALUES_FOR_STABILITY = 3;
+        const tail = takeRight(recent_measurements, MINIMUM_EQUAL_VALUES_FOR_STABILITY);
+        if (tail.length < MINIMUM_EQUAL_VALUES_FOR_STABILITY) {
+          return false;
+        }
+
+        let previous = null;
+        for (let i = 0; i < tail.length; i++) {
+          const value = tail[i];
+          if (previous !== null && value !== previous) {
+            return false;
+          }
+          previous = value;
+        }
+
+        return true;
+      },
+
+      addMeasurement(measurement) {
+        recent_measurements.push(measurement);
+        return recent_measurements;
+      },
+    };
+  },
+};
+
+export default api;

--- a/src/transmission/http-transmitter.js
+++ b/src/transmission/http-transmitter.js
@@ -1,0 +1,42 @@
+import request from 'request';
+
+const internals = {
+  sendRequest(req_opts) {
+    return new Promise((resolve, reject) => {
+      request(req_opts, (err, res, response_body) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        else if (res.statusCode >= 400) {
+          reject(new Error(`Request responded with status code ${res.statusCode}`));
+          return;
+        }
+        resolve(response_body);
+      });
+    });
+  },
+};
+
+const api = {
+  create(config) {
+    return {
+      transmit(payload) {
+        const req_opts = {
+          method: config.method,
+          url: config.target_url,
+          json: payload,
+        };
+        return internals.sendRequest(req_opts);
+      },
+    };
+  },
+};
+
+export default api;
+
+
+/* istanbul ignore else */
+if (process.env.NODE_ENV === 'test') {
+  api.internals = internals;
+}

--- a/src/transmission/weight-transmitter.js
+++ b/src/transmission/weight-transmitter.js
@@ -1,0 +1,19 @@
+/**
+ * Sends weight value to wherever suitable, e.g. an external API.
+ */
+
+
+const api = {
+  create(transmitter) {
+    return {
+      transmitWeight(grams) {
+        return transmitter.transmit({
+          grams,
+          timestamp: new Date().toISOString(),
+        });
+      },
+    };
+  },
+};
+
+export default api;

--- a/src/weight-reader.js
+++ b/src/weight-reader.js
@@ -1,0 +1,47 @@
+/**
+ * Reads weight from a file and passes it along to a weight responder.
+ */
+
+import Tail from 'always-tail';
+
+
+const internals = {
+
+  provideTail(file_path) {
+    const tail_separator = '\n';
+    return new Tail(file_path, tail_separator, { interval: 100 });
+  },
+
+  handleUpdate(weight_responder, data) {
+    weight_responder.respondToWeight(data);
+  },
+
+};
+
+const api = {
+
+  create(file_path, weight_responder) {
+    const tail = internals.provideTail(file_path);
+    tail.on('line', function(data) {
+      internals.handleUpdate(weight_responder, data);
+    });
+    tail.on('error', function(data) {
+      console.error('weight-reader failed:', data);
+    });
+
+    return {
+      read() {
+        tail.watch();
+      },
+    };
+  },
+
+};
+
+export default api;
+
+
+/* istanbul ignore else */
+if (process.env.NODE_ENV === 'test') {
+  api.internals = internals;
+}

--- a/src/weight-responder.js
+++ b/src/weight-responder.js
@@ -1,0 +1,36 @@
+/**
+ * Acts on a scale weight value and acts accordingly.
+ */
+
+const internals = {
+  parseWeightToGrams(weight_str) {
+    // weight_str is something like "1234 g" (but could also be "oz" sometimes)
+    return parseInt(weight_str, 10);
+  },
+};
+
+const api = {
+  create(weight_transmitter, measurement_analyzer) {
+    return {
+      respondToWeight(weight_str) {
+        const grams = internals.parseWeightToGrams(weight_str);
+
+        console.log('Responding to read weight: %d g', grams);
+
+        measurement_analyzer.addMeasurement(grams);
+        if (measurement_analyzer.isStabilized()) {
+          return weight_transmitter.transmitWeight(grams)
+              .then(() => {
+                console.log('Transmitted weight: %d g', grams);
+              })
+              .catch(err => {
+                console.error('Failed to transmit weight', err);
+              });
+        }
+        return Promise.resolve();
+      },
+    };
+  },
+};
+
+export default api;

--- a/test/acceptance/index-test.js
+++ b/test/acceptance/index-test.js
@@ -1,0 +1,12 @@
+describe('test/acceptance/index-test.js', function() {
+
+  describe('load index', () => {
+
+    it('should not fail', () => {
+      const index = require('../../src/index');
+      should.exist(index);
+    });
+
+  });
+
+});

--- a/test/unit/measurement-analyzer-test.js
+++ b/test/unit/measurement-analyzer-test.js
@@ -1,0 +1,63 @@
+import measurement_analyzer from '../../src/measurement-analyzer';
+
+
+describe(__filename, function() {
+
+  describe('with created analyzer', () => {
+    let analyzer;
+
+    beforeEach(() => {
+      analyzer = measurement_analyzer.create();
+    });
+
+    describe('having no added measurements', () => {
+
+      describe('adding one measurement', () => {
+        const grams = 1000;
+
+        it('should return array of recent measurements', () => {
+          const measurements = analyzer.addMeasurement(grams);
+          measurements.should.eql([grams]);
+        });
+
+        it('should not consider measurements stable', () => {
+          analyzer.addMeasurement(grams);
+          analyzer.isStabilized().should.eql(false);
+        });
+
+      });
+
+      describe('adding equal measurement 3 times (min required count) to 1 different measurement', () => {
+        const initial_grams = 2000;
+        const grams = 1000;
+
+        beforeEach(() => {
+          analyzer.addMeasurement(initial_grams);
+        });
+
+        it('should return array of recent measurements', () => {
+          analyzer.addMeasurement(grams);
+          analyzer.addMeasurement(grams);
+          const measurements = analyzer.addMeasurement(grams);
+          measurements.should.eql([
+            initial_grams,
+            grams,
+            grams,
+            grams,
+          ]);
+        });
+
+        it('should consider measurements stable', () => {
+          analyzer.addMeasurement(grams);
+          analyzer.addMeasurement(grams);
+          analyzer.addMeasurement(grams);
+          analyzer.isStabilized().should.eql(true);
+        });
+
+      });
+
+    });
+
+  });
+
+});

--- a/test/unit/transmission/http-transmitter-test.js
+++ b/test/unit/transmission/http-transmitter-test.js
@@ -1,0 +1,65 @@
+import http_transmitter from '../../../src/transmission/http-transmitter';
+
+
+describe(__filename, function() {
+  let sinon_sandbox;
+
+  beforeEach(() => {
+    sinon_sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sinon_sandbox.restore();
+  });
+
+  describe('with valid config', () => {
+    let mock_config;
+    let transmitter;
+
+    beforeEach(() => {
+      mock_config = {
+        target_url: 'http://mock.com/v1/path/to/scale',
+        method: 'patch',
+      };
+    });
+
+    beforeEach(() => {
+      const http_response = {};
+      sinon_sandbox.stub(http_transmitter.internals, 'sendRequest').returns(Promise.resolve(http_response));
+    });
+
+    beforeEach(() => {
+      transmitter = http_transmitter.create(mock_config);
+    });
+
+    describe('with valid weight', () => {
+      const grams = 1234.5;
+      const payload = {
+        grams,
+        timestamp: new Date().toISOString(),
+      };
+
+      it('should execute request()', () => {
+        return transmitter.transmit(payload).then(() => {
+          http_transmitter.internals.sendRequest.should.have.callCount(1);
+        });
+      });
+
+      it('should have proper request options', () => {
+        return transmitter.transmit(payload).then(() => {
+          const call_args = http_transmitter.internals.sendRequest.getCall(0).args;
+          call_args[0].should.eql({
+            method: mock_config.method,
+            url: mock_config.target_url,
+            json: payload
+          });
+        });
+      });
+
+    });
+
+  });
+
+
+
+});

--- a/test/unit/transmission/weight-transmitter-test.js
+++ b/test/unit/transmission/weight-transmitter-test.js
@@ -1,0 +1,48 @@
+import weight_transmitter from '../../../src/transmission/weight-transmitter';
+
+describe(__filename, function() {
+  let sinon_sandbox;
+
+  beforeEach(() => {
+    sinon_sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sinon_sandbox.restore();
+  });
+
+  describe('transmitWeight', () => {
+
+    describe('with a weight in grams', () => {
+      const grams = 1234.5;
+
+      describe('using a http transmitter', () => {
+        let http_transmitter;
+        let transmitter;
+
+        beforeEach(() => {
+          http_transmitter = {
+            transmit: function() {
+              return Promise.resolve();
+            }
+          };
+          sinon_sandbox.spy(http_transmitter, 'transmit');
+        });
+
+        beforeEach(() => {
+          transmitter = weight_transmitter.create(http_transmitter);
+        });
+
+        it('should use HTTP transmitter to send request', () => {
+          return transmitter.transmitWeight(http_transmitter, grams).then(() => {
+            http_transmitter.transmit.should.have.callCount(1);
+          });
+        });
+
+      });
+
+    });
+
+  });
+
+});

--- a/test/unit/weight-reader-test.js
+++ b/test/unit/weight-reader-test.js
@@ -1,0 +1,53 @@
+import weight_reader from '../../src/weight-reader';
+
+describe('test/unit/weight-reader-test.js', function() {
+  let sinon_sandbox;
+
+  beforeEach(() => {
+    sinon_sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sinon_sandbox.restore();
+  });
+
+  describe('create', () => {
+
+    describe('with valid file_path, weight_responder', () => {
+      const file_path = '/dev/null';
+      let weight_responder;
+      let mock_tail;
+      let tail_on_spy;
+
+      beforeEach('mockWeightResponder', () => {
+        weight_responder = {};
+      });
+
+      beforeEach(() => {
+        mock_tail = weight_reader.internals.provideTail();
+        tail_on_spy = sinon_sandbox.spy(mock_tail, 'on');
+        sinon_sandbox.stub(weight_reader.internals, 'provideTail').returns(mock_tail);
+      });
+
+      it('should return object with read() function', () => {
+        const reader = weight_reader.create(file_path, weight_responder);
+        reader.should.have.keys([
+          'read',
+        ]);
+      });
+
+      it('should listen on "line" event', () => {
+        weight_reader.create(file_path, weight_responder);
+        tail_on_spy.getCall(0).args[0].should.eql('line');
+      });
+
+      it('should listen on "error" event', () => {
+        weight_reader.create(file_path, weight_responder);
+        tail_on_spy.getCall(1).args[0].should.eql('error');
+      });
+
+    });
+
+  });
+
+});

--- a/test/unit/weight-responder-test.js
+++ b/test/unit/weight-responder-test.js
@@ -1,0 +1,70 @@
+import weight_responder from '../../src/weight-responder';
+import analyzer from '../../src/measurement-analyzer';
+import weight_transmitter from '../../src/transmission/weight-transmitter';
+
+describe(__filename, function() {
+  let sinon_sandbox;
+
+  beforeEach(() => {
+    sinon_sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sinon_sandbox.restore();
+  });
+
+  describe('with a created responder', () => {
+    let measurement_analyzer;
+    let responder;
+    let transmitter;
+
+    beforeEach(() => {
+      measurement_analyzer = analyzer.create();
+      sinon_sandbox.spy(measurement_analyzer, 'addMeasurement');
+    });
+
+    beforeEach(function mockWeightTransmission() {
+      const http_transmitter = { transmit: () => Promise.resolve() };
+      transmitter = weight_transmitter.create(http_transmitter);
+      sinon_sandbox.spy(transmitter, 'transmitWeight');
+    });
+
+    beforeEach(() => {
+      responder = weight_responder.create(transmitter, measurement_analyzer);
+    });
+
+    describe('respondToWeight', () => {
+
+      describe('with weight as string', () => {
+        const measurement_str = '1234.5 g';
+        const grams = 1234;
+
+        describe('when measurements are stabilized', () => {
+
+          beforeEach(() => {
+            sinon_sandbox.stub(measurement_analyzer, 'isStabilized').returns(true);
+          });
+
+          it('should add measurement in grams, rounded to int', () => {
+            return responder.respondToWeight(measurement_str).then(() => {
+              measurement_analyzer.addMeasurement.should.have.callCount(1);
+              const call_args = measurement_analyzer.addMeasurement.getCall(0).args;
+              call_args[0].should.eql(grams);
+            });
+          });
+
+          it('should transmit weight', () => {
+            return responder.respondToWeight(measurement_str).then(() => {
+              transmitter.transmitWeight.should.have.callCount(1);
+            });
+          });
+
+        });
+
+      });
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
# Scale Reader

Node application that reads a file stream, parses its input as a weight measurement and sends it somewhere.

**Probably only useful in combination with:**
- https://github.com/Springworks/usbscale
- https://github.com/Springworks/usbscale-runner
## Usage

Install NPM module:

```
npm install -g scale-reader
```

Read data from a file and transmit stable values to a server endpoint:

```
scale-reader --help

  Usage: scale-reader [options]

  Options:

    -h, --help                                output usage information
    -F, --filename <path to file>             Path to file to read weight from
    -T, --target-url <url to PATCH endpoint>  Target URL
```
## License

MIT
