### PR TITLE
Make babel a true dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "homepage": "https://github.com/Springworks/node-scale-reader",
   "devDependencies": {
     "@springworks/test-harness": "1.2.2",
-    "babel": "5.8.29",
     "babel-eslint": "4.1.3",
     "eslint": "1.7.3",
     "eslint-config-springworks": "3.2.0",
@@ -43,6 +42,7 @@
     "request": "2.65.0",
     "always-tail": "0.2.0",
     "commander": "2.9.0",
+    "babel": "5.8.29",
     "lodash.takeright": "3.0.0"
   }
 }


### PR DESCRIPTION
Make babel a true dependency

Fixes issue where babel/polyfill is required.
