### PR TITLE
Upgrade babel to 6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["es2015"],
+  "plugins": ["transform-runtime", "transform-strict-mode"]
+}

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-require('babel/polyfill');
+require('babel-polyfill');
 
 var cli = require('../lib/cli');
 cli.run(process);

--- a/package.json
+++ b/package.json
@@ -30,7 +30,13 @@
   "homepage": "https://github.com/Springworks/node-scale-reader",
   "devDependencies": {
     "@springworks/test-harness": "1.2.2",
+    "babel-cli": "6.3.17",
+    "babel-core": "6.3.26",
     "babel-eslint": "4.1.3",
+    "babel-plugin-transform-runtime": "6.3.13",
+    "babel-plugin-transform-strict-mode": "6.3.13",
+    "babel-preset-es2015": "6.3.13",
+    "babel-runtime": "6.3.19",
     "eslint": "1.7.3",
     "eslint-config-springworks": "3.2.0",
     "eslint-plugin-mocha": "1.0.0",
@@ -39,10 +45,10 @@
     "mocha": "2.3.4"
   },
   "dependencies": {
-    "request": "2.65.0",
     "always-tail": "0.2.0",
+    "babel-polyfill": "6.3.14",
     "commander": "2.9.0",
-    "babel": "5.8.29",
-    "lodash.takeright": "3.0.0"
+    "lodash.takeright": "3.0.0",
+    "request": "2.65.0"
   }
 }

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -4,4 +4,4 @@
 --slow 200
 --reporter spec
 --require @springworks/test-harness
---compilers js:babel/register
+--compilers js:babel-core/register


### PR DESCRIPTION
Upgrade babel to 6

Removes need for all of babel as true dependency, since babel-polyfill can be used.
