### PR TITLE
Use `.default` to access exported function

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3,4 +3,4 @@
 require('babel-polyfill');
 
 var cli = require('../lib/cli');
-cli.run(process);
+cli.default.run(process);


### PR DESCRIPTION
Use `.default` to access exported function
